### PR TITLE
Add requirement that we use mozilla-aws-cli <= 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2019-12-06
+### Added
+* Requirement that we use mozilla-aws-cli <= 0.1.1 to ensure using the old
+  idtoken_for_roles_url format ending in "/roles"
+
 ## [1.0.0] - 2019-11-26
 ### Added
 * A long description to the package
@@ -15,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Initial release of the mozilla-aws-cli-mozilla configuration package
 
-[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v0.0.1...v1.0.0
 [0.0.1]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/releases/tag/v0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-mozilla_aws_cli
+mozilla_aws_cli<=0.1.1

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3"
     ],
-    install_requires=["mozilla_aws_cli"],
+    install_requires=["mozilla_aws_cli<=0.1.1"],
     keywords="maws Mozilla AWS CLI config",
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This will ensure using the old idtoken_for_roles_url format ending in "/roles"