### PR TITLE
Change idtoken_for_roles_url format to https://example.com/roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2020-02-13
+### Changed
+* Requirement that we use mozilla-aws-cli >= 1.1.0 to ensure using the original
+  idtoken_for_roles_url format ending in "/roles"
+  * This reverts the change in 1.2.0
+* The idtoken_for_roles_url value to the new form
+
 ## [1.2.0] - 2019-12-06
 ### Changed
 * Requirement that we use mozilla-aws-cli >= 0.2.0 to ensure using the new
@@ -26,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Initial release of the mozilla-aws-cli-mozilla configuration package
 
-[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v0.0.1...v1.0.0

--- a/mozilla_aws_cli_config/__init__.py
+++ b/mozilla_aws_cli_config/__init__.py
@@ -1,5 +1,5 @@
 config = {
     "client_id": "N7lULzWtfVUDGymwDs0yDEq6ZcwmFazj",
-    "idtoken_for_roles_url": "https://roles-and-aliases.security.mozilla.org/",
+    "idtoken_for_roles_url": "https://roles-and-aliases.security.mozilla.org/roles",
     "well_known_url": "https://auth.mozilla.auth0.com/.well-known/openid-configuration"
 }

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3"
     ],
-    install_requires=["mozilla_aws_cli>=0.2.0"],
+    install_requires=["mozilla_aws_cli>=1.1.0"],
     keywords="maws Mozilla AWS CLI config",
     long_description=readme,
     long_description_content_type='text/markdown',
     packages=["mozilla_aws_cli_config"],
     url="https://github.com/mozilla-iam/mozilla-aws-cli-mozilla",
-    version="1.2.0",
+    version="1.3.0",
     zip_safe=False,
 )


### PR DESCRIPTION
Updated the requirement that we use mozilla-aws-cli >= 1.1.0 to ensure using the original
idtoken_for_roles_url format ending in "/roles"
* This reverts the change in 1.2.0

Updated the idtoken_for_roles_url value to the new form

This relates to mozilla-iam/mozilla-aws-cli#196