### PR TITLE
Update to new version of maws

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,24 @@
+name: Build and Publish Python Package
+on:
+  push:
+    tags:
+      - 'v*'  # Run when "v*" version tags are created like "v1.0.0"
+jobs:
+  release:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    if: github.repository == 'mozilla-iam/mozilla-aws-cli-mozilla'  # Only deploy from mozilla-iam not from forks
+    steps:
+      - name: Install build dependencies
+        run: python3 -m pip install --upgrade wheel setuptools
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build package
+        run: python3 setup.py sdist bdist_wheel --universal
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.1.0
+        with:
+          user: __token__
+          # password: ${{ secrets.TEST_PYPI_TOKEN }}
+          # repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2022-04-14
+### Changed
+* Requirement that we use mozilla-aws-cli >= 1.2.5 to prevent installing with a
+  conflicting version of Werkzeug
+
 ## [1.3.0] - 2020-02-13
 ### Changed
 * Requirement that we use mozilla-aws-cli >= 1.1.0 to ensure using the original
@@ -33,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Initial release of the mozilla-aws-cli-mozilla configuration package
 
-[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/mozilla-iam/mozilla-aws-cli-mozilla/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ with the specific configuration settings for Mozilla employees and contributors.
 
 This package is only needed if you intend to use the `maws` to access AWS 
 accounts owned by Mozilla.
+
+To install it, run
+```
+pip install --user mozilla-aws-cli-mozilla
+```

--- a/setup.py
+++ b/setup.py
@@ -11,18 +11,18 @@ setup(
     author="Mozilla Enterprise Information Security",
     author_email="iam@discourse.mozilla.org",
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3"
     ],
-    install_requires=["mozilla_aws_cli>=1.1.0"],
+    install_requires=["mozilla_aws_cli>=1.2.5"],
     keywords="maws Mozilla AWS CLI config",
     long_description=readme,
     long_description_content_type='text/markdown',
     packages=["mozilla_aws_cli_config"],
     url="https://github.com/mozilla-iam/mozilla-aws-cli-mozilla",
-    version="1.3.0",
+    version="1.3.1",
     zip_safe=False,
 )


### PR DESCRIPTION
* Changed requirement that we use mozilla-aws-cli >= 1.2.5 to prevent installing with a conflicting version of Werkzeug
* Add GitHub actions build and publish capability